### PR TITLE
Revert "attach to game window by SetParent"

### DIFF
--- a/BepInEx.SplashScreen.GUI/SplashScreen.Designer.cs
+++ b/BepInEx.SplashScreen.GUI/SplashScreen.Designer.cs
@@ -171,6 +171,7 @@ namespace BepInEx.SplashScreen
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "The game is loading...";
+            this.TopMost = true;
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ResumeLayout(false);
 


### PR DESCRIPTION
Reverts BepInEx/BepInEx.SplashScreen#2
Turns out there were serious issues with using SetParent where the splash screen stops updating when main game window is not responding as it loads.